### PR TITLE
added feature to display minerals when the facility button is pushed

### DIFF
--- a/src/scripts/Facilities.js
+++ b/src/scripts/Facilities.js
@@ -1,5 +1,22 @@
 import { getFacilities } from "./database.js"
 import { getOrderBuilder } from "./database.js"
+import { facilityMinerals } from "./FacilityMinerals.js"
+
+
+
+document.addEventListener(
+    "click",
+    (event) => {
+        debugger
+        const itemClicked = event.target
+        if (itemClicked.id.startsWith("facility")) {
+        const [,mineralListId] = itemClicked.id.split("--")
+        const minerals = facilityMinerals()
+        const mineralList = document.getElementById(mineralListId)
+        mineralList.innerHTML = minerals
+        }
+    }
+)
 
 
 //import builder object and save in var state
@@ -8,7 +25,6 @@ import { getOrderBuilder } from "./database.js"
 const facilities = getFacilities()
 export const FacilityList = () => {
     const state = getOrderBuilder()
-    console.log(state)
     let html = `
     <div class="facilityList">`
 
@@ -20,8 +36,9 @@ export const FacilityList = () => {
                 <h1>${facility.name}</h1>
                 <button ${state.governorId > 0 ? "" : "disabled"}
                 class="facility__selector" 
-                id=facility--"${facility.id}">
+                id="facility--${facility.id}">
                 ${facility.name} is Open <br></br> Enter and Collect Thy Metals  </button>
+                <div id="${facility.id}"></div>
                 </div>`
             } else {
                 return `<div class="facilityId--${facility.id}"><h1>${facility.name}</h1> </div>`

--- a/src/scripts/Facilities.js
+++ b/src/scripts/Facilities.js
@@ -2,8 +2,9 @@ import { getFacilities } from "./database.js"
 import { getOrderBuilder } from "./database.js"
 import { facilityMinerals } from "./FacilityMinerals.js"
 
-
-
+//captures event click and creates a var with id of event target
+//calls facilityMinerals to render minerals radio list in the element with 
+//same id number-string as event.target displaying the minerals below the button clicked
 document.addEventListener(
     "click",
     (event) => {

--- a/src/scripts/Facilities.js
+++ b/src/scripts/Facilities.js
@@ -7,7 +7,6 @@ import { facilityMinerals } from "./FacilityMinerals.js"
 document.addEventListener(
     "click",
     (event) => {
-        debugger
         const itemClicked = event.target
         if (itemClicked.id.startsWith("facility")) {
         const [,mineralListId] = itemClicked.id.split("--")

--- a/src/scripts/FacilityMinerals.js
+++ b/src/scripts/FacilityMinerals.js
@@ -11,9 +11,9 @@ document.addEventListener(
 )
 
 
-export const Minerals = () => {
+export const facilityMinerals = () => {
     const minerals = getMinerals()
-    let html = "<ul>"
+    let html = "<ul id='facilityMinerals' >"
 
     const listItemsArray = minerals.map(
         (mineral) => {

--- a/src/scripts/Governors.js
+++ b/src/scripts/Governors.js
@@ -12,7 +12,7 @@ document.addEventListener(
 )
 
 
-//rendesr govenor option list with the isActive=false governors ommitted
+//renders govenor option list with the isActive=false governors ommitted
 const governors = getGovernors()
 export const Governors = () => {
     let html = `


### PR DESCRIPTION
# Description

added an event listener each facility button that renders the list of mineral below the respective button 

i did notice that the governors list is not working properly--it does not show the clicked governor but only renders the first governor 
Fixes # (issue)

## Type of change
added feature to render radio elements for minerals
Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

served the site and tested the facility buttons from the browser


# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
